### PR TITLE
Feature/offline jwt validation

### DIFF
--- a/broker-admin/src/test/resources/openid-config.properties
+++ b/broker-admin/src/test/resources/openid-config.properties
@@ -1,4 +1,6 @@
 openid.server=http://myauthserver:8080/auth/realms/myauthrealm
-openid.client.id=myclientid
-openid.client.secret=myclientsecret
+openid.jwks_uri=http://myauthserver:8080/auth/realms/myauthrealm/protocol/openid-connect/certs
 openid.claim.site-name=site-name
+# Allowed values are: HS256,HS384,HS512,RS256,RS384,RS512,ES256,ES384,ES512,PS256,PS384,PS512
+# Separate with comma
+openid.algorithms=RS256,RS384,RS512

--- a/broker-auth-openid/pom.xml
+++ b/broker-auth-openid/pom.xml
@@ -79,7 +79,11 @@
 			<artifactId>gson</artifactId>
 			<version>2.8.6</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.bitbucket.b_c</groupId>
+			<artifactId>jose4j</artifactId>
+			<version>0.7.6</version>
+		</dependency>
 		<dependency>
 			<artifactId>lombok</artifactId>
 			<groupId>org.projectlombok</groupId>

--- a/broker-auth-openid/pom.xml
+++ b/broker-auth-openid/pom.xml
@@ -75,11 +75,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.8.6</version>
-		</dependency>
-		<dependency>
 			<groupId>org.bitbucket.b_c</groupId>
 			<artifactId>jose4j</artifactId>
 			<version>0.7.6</version>

--- a/broker-auth-openid/src/main/java/org/aktin/broker/auth/openid/OpenIdAuthProvider.java
+++ b/broker-auth-openid/src/main/java/org/aktin/broker/auth/openid/OpenIdAuthProvider.java
@@ -11,6 +11,10 @@ import org.aktin.broker.server.auth.HeaderAuthentication;
 public class OpenIdAuthProvider extends AbstractAuthProvider{
 	private OpenIdConfig config;
 
+	public OpenIdAuthProvider() {
+		config = null; // lazy init, load later in getInstance by using supplied path
+	}
+
 	public OpenIdAuthProvider(InputStream in) {
 		this.config = new OpenIdConfig(in);
 	}

--- a/broker-auth-openid/src/main/java/org/aktin/broker/auth/openid/OpenIdConfig.java
+++ b/broker-auth-openid/src/main/java/org/aktin/broker/auth/openid/OpenIdConfig.java
@@ -2,27 +2,35 @@ package org.aktin.broker.auth.openid;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
+import java.util.stream.Collectors;
 import lombok.Data;
 
 @Data
 public class OpenIdConfig {
 
+  private String jwks_uri;
   private String auth_host;
-  private String clientId;
-  private String clientSecret;
   private String siteNameClaim;
+  private List<String> allowedAlgorithms;
 
   public OpenIdConfig(InputStream in) {
     Properties prop = new Properties();
     try {
       prop.load(in);
+      setJwks_uri(prop.getProperty("openid.jwks_uri"));
       setAuth_host(prop.getProperty("openid.server"));
-      setClientId(prop.getProperty("openid.client.id"));
-      setClientSecret(prop.getProperty("openid.client.secret"));
       setSiteNameClaim(prop.getProperty("openid.claim.site-name"));
+      setAllowedAlgorithms(extractAlgorithmsList(prop.getProperty("openid.algorithms")));
     } catch (IOException e) {
       e.printStackTrace();
     }
+  }
+
+  private List<String> extractAlgorithmsList(String algorithmsString) {
+    List<String> algorithmsList = Arrays.asList(algorithmsString.split(","));
+    return algorithmsList.stream().map(String::trim).collect(Collectors.toList());
   }
 }

--- a/broker-auth-openid/src/test/resources/openid-config.properties
+++ b/broker-auth-openid/src/test/resources/openid-config.properties
@@ -1,4 +1,6 @@
 openid.server=http://myauthserver:8080/auth/realms/myauthrealm
-openid.client.id=myclientid
-openid.client.secret=myclientsecret
+openid.jwks_uri=http://myauthserver:8080/auth/realms/myauthrealm/protocol/openid-connect/certs
 openid.claim.site-name=site-name
+# Allowed values are: HS256,HS384,HS512,RS256,RS384,RS512,ES256,ES384,ES512,PS256,PS384,PS512
+# Separate with comma
+openid.algorithms=RS256,RS384,RS512

--- a/broker-client/pom.xml
+++ b/broker-client/pom.xml
@@ -97,5 +97,10 @@
 			<version>3.8.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-authz-client</artifactId>
+			<version>12.0.4</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/broker-client/src/main/java/org/aktin/broker/client2/auth/OpenIdAuthentication.java
+++ b/broker-client/src/main/java/org/aktin/broker/client2/auth/OpenIdAuthentication.java
@@ -1,18 +1,27 @@
 package org.aktin.broker.client2.auth;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import org.keycloak.authorization.client.AuthzClient;
 
-public class OpenIdAuthentication extends HttpAuthorizationBearerAuth{
-	private String apiKey;
+public class OpenIdAuthentication extends HttpAuthorizationBearerAuth {
 
-	public OpenIdAuthentication(String apiKey) {
-		this.apiKey = apiKey;
-	}
+  private String apiKey;
 
-	@Override
-	protected String getBearerToken() throws IOException {
-		return AuthzClient.create().obtainAccessToken().getToken();
-	}
+  public OpenIdAuthentication(String apiKey) {
+    this.apiKey = apiKey;
+  }
+
+  @Override
+  protected String getBearerToken() throws IOException {
+    try (InputStream in = Files.newInputStream(Paths.get("keycloak.json"))) {
+      return AuthzClient.create(in).obtainAccessToken().getToken();
+    } catch (IOException e) {
+			System.err.println("Unable to read keycloak.json: " + e.getMessage());
+			throw(e);
+		}
+  }
 
 }

--- a/broker-client/src/main/java/org/aktin/broker/client2/auth/OpenIdAuthentication.java
+++ b/broker-client/src/main/java/org/aktin/broker/client2/auth/OpenIdAuthentication.java
@@ -1,0 +1,18 @@
+package org.aktin.broker.client2.auth;
+
+import java.io.IOException;
+import org.keycloak.authorization.client.AuthzClient;
+
+public class OpenIdAuthentication extends HttpAuthorizationBearerAuth{
+	private String apiKey;
+
+	public OpenIdAuthentication(String apiKey) {
+		this.apiKey = apiKey;
+	}
+
+	@Override
+	protected String getBearerToken() throws IOException {
+		return AuthzClient.create().obtainAccessToken().getToken();
+	}
+
+}

--- a/broker-client/src/test/resources/keycloak.json
+++ b/broker-client/src/test/resources/keycloak.json
@@ -1,0 +1,10 @@
+{
+  "realm": "myrealm",
+  "auth-server-url": "myauthserver",
+  "ssl-required": "external",
+  "resource": "myclientid",
+  "credentials": {
+    "secret": "myclientsecret"
+  },
+  "confidential-port": 0
+}


### PR DESCRIPTION
Client now retrieves keycloak token. Broker does no longer use the introspection endpoint but checks the token itself.

To get it running, the following is needed:

- keycloak.json: get it from keycloak. Go to your client there, and click on the "installation" tab and select "keycloak oidc json" format. Copy the file to the target folder (where sysproc.properties is copied to as well)
- add the OpenIdAuthProvider to the list of providers. In run_broker.sh, add "-Dbroker.auth.provider=org.aktin.broker.auth.apikey.ApiKeyPropertiesAuthProvider,org.aktin.broker.auth.cred.CredentialTokenAuthProvider,org.aktin.broker.auth.openid.OpenIdAuthProvider" or if wanted, add it to the defaultconfig (Putting it before the others lead to the admin gui no longer being accessible for me)
- adapt openid-config.properties (broker-admin) to contain the correct urls to your keycloak and copy it to the place where you extracted the broker admin dist zip to (place it where api-keys.properties is)