### PR TITLE
Timezone problem fixed.

### DIFF
--- a/broker-admin/src/main/resources/webapp/load-request-template.js
+++ b/broker-admin/src/main/resources/webapp/load-request-template.js
@@ -1,8 +1,16 @@
 
 function isoToLocalDate(iso){
-	// TODO convert to local timezone
-	// remove zone offset from timestamp
-	return iso.substring(0,19);
+	console.log("ISO String",iso);
+	newTime=new Date(iso);
+	//get offset
+	offset = newTime.getTimezoneOffset();
+
+	// apply date specific timezone
+	newDate = new Date(newTime.getTime() - (offset*60*1000));
+	//cut off timezone information after applying offset
+	finalResult=newDate.toISOString().split('Z')[0];
+	console.log("localized String to German timezone",finalResult);
+	return finalResult;
 }
 
 

--- a/broker-admin/src/main/resources/webapp/requests.js
+++ b/broker-admin/src/main/resources/webapp/requests.js
@@ -54,9 +54,9 @@ function init(){
 //	init();
 //});
 Date.prototype.toDateInputValue = (function(){
-	var local = new Date(this);
-	local.setMinutes(this.getMinutes() - this.getTimezoneOffset());
+	var local = new Date(this);//.toISOString();
 	return local.toJSON().slice(0,10);
+	//return local
 });
 
 function loadTemplateTypes(){
@@ -123,9 +123,9 @@ function localTimeToISO(local_str){
 		local_str += ":00";
 	}
 	
-	// TODO parse local_str and convert and return YYYY-MM-DDT00:00:00Z
-	local_str += "Z"; // XXX 
-	return local_str;
+
+	console.log("Local Time",local_str)
+	return new Date(local_str).toISOString();
 }
 
 

--- a/broker-admin/src/main/resources/webapp/template/aktin.query.request/script.js
+++ b/broker-admin/src/main/resources/webapp/template/aktin.query.request/script.js
@@ -35,7 +35,7 @@ function initializeForm(){
 		var d = new Date();
 		d.setDate(1);
 		console.log('Setting reference date',d);
-		$('#new_request input[name="reference"]').val(d.toDateInputValue()+"T00:00:00");
+		$('#new_request input[name="reference"]').val(d.toDateInputValue()+"T00:00");
 	}));
 	// switch between single/repeating executions
 	$('#x_exec legend:first-child').css('cursor','pointer').click(function(){


### PR DESCRIPTION
Request timestamps are exported correctly in UTC and converted to local time (Central European Time) when loading previous requests.  

The loading of previous requests works correctly under the assumption that user's system are on Central European timezone with summer time. 


