### PR TITLE
Add CI to build docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,96 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - v[0-9]+.[0-9]+**
+  pull_request:
+    branches:
+    - master
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 15
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 15
+
+      - name: Cache Local Maven Repo
+        uses: actions/cache@v2.1.2
+        with:
+          path: ~/.m2/repository
+          key: maven-repo
+
+      - name: Build
+        run: mvn -B package
+
+  build-broker:
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Login to GitHub Docker Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Prepare Version
+      id: prep
+      run: |
+        echo ::set-output name=repository::$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+        echo ::set-output name=version::${GITHUB_REF#refs/tags/v}
+
+    - name: Build and push docker image for aktin-broker
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: docker/aktin-broker/Dockerfile
+        tags: |
+          ghcr.io/${{ steps.prep.outputs.repository }}/aktin-broker:latest
+          ghcr.io/${{ steps.prep.outputs.repository }}/aktin-broker:${{ steps.prep.outputs.version }}
+        push: true
+
+  build-client:
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Login to GitHub Docker Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Prepare Version
+      id: prep
+      run: |
+        echo ::set-output name=repository::$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+        echo ::set-output name=version::${GITHUB_REF#refs/tags/v}
+
+    - name: Build and push docker image for aktin-broker
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: docker/aktin-client/Dockerfile
+        tags: |
+          ghcr.io/${{ steps.prep.outputs.repository }}/aktin-client:latest
+          ghcr.io/${{ steps.prep.outputs.repository }}/aktin-client:${{ steps.prep.outputs.version }}
+        push: true

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,14 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<artifactId>maven-release-plugin</artifactId>
+				<configuration>
+					<scmCommentPrefix>[ci skip]</scmCommentPrefix>
+					<scmReleaseCommitComment>[release] prepare release @{releaseLabel}</scmReleaseCommitComment>
+					<tagNameFormat>v@{project.version}</tagNameFormat>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<!-- profile which signs artifacts only during release -->

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<packaging>pom</packaging>
-	
+
 	<groupId>org.aktin</groupId>
 	<artifactId>broker</artifactId>
 	<version>1.3-SNAPSHOT</version>
@@ -107,7 +107,7 @@
 					<!-- forces newer version, old 2.3.2 contains bugs -->
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-release-plugin</artifactId>
-					<version>2.5.3</version>
+					<version>3.0.0-M1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -127,7 +127,7 @@
 					<artifactId>maven-surefire-plugin</artifactId>
 					<configuration>
 						<systemProperties>
-							<property> 
+							<property>
 								<name>java.util.logging.config.file</name>
 								<value>src/test/resources/logging.properties</value>
 							</property>


### PR DESCRIPTION
Build docker images for aktin-broker and aktin-client when a git tag is pushed to github and the tag label matches the regex pattern `v[0-9]+\.[0-9]+.*`. Both docker images are pushed to the github docker repository _ghcr.io_.

The maven release plugin is configured to label the tags according to the pattern above and only trigger the CI workflow for the release commit. But using `mvn release` is optional as any tag being pushed to github and conforming to the above pattern will be build.