### PR TITLE
Vulnerable dependencies updates

### DIFF
--- a/broker-admin/pom.xml
+++ b/broker-admin/pom.xml
@@ -15,7 +15,8 @@
 		<version>1.5.2-SNAPSHOT</version>
 	</parent>
 	<properties>
-		<jetty.version>9.4.51.v20230217</jetty.version>
+		<jetty.version>9.4.53.v20231009</jetty.version>
+		<jersey.version>2.41</jersey.version>
 	</properties>
 	
 	
@@ -153,27 +154,27 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-server</artifactId>
-			<version>2.30.1</version>
+			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.containers</groupId>
 			<artifactId>jersey-container-servlet-core</artifactId>
-			<version>2.30.1</version>
+			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.containers</groupId>
 			<artifactId>jersey-container-jetty-http</artifactId>
-			<version>2.30.1</version>
+			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.ext.cdi</groupId>
 			<artifactId>jersey-cdi1x-servlet</artifactId>
-			<version>2.30.1</version>
+			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.inject</groupId>
 			<artifactId>jersey-hk2</artifactId>
-			<version>2.30.1</version>
+			<version>${jersey.version}</version>
 		</dependency>
 		<!-- don't need JSON support on server
 		<dependency>
@@ -184,7 +185,14 @@
 		-->
 		<!-- SLF4j Logging into JUL/JDK framework -->
 		<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-jdk14 -->
-		
+
+		<!-- Starting from Jersey 2.30 onwards, JAXB support was moved to a separate module  -->
+		<dependency>
+			<groupId>org.glassfish.jersey.media</groupId>
+			<artifactId>jersey-media-jaxb</artifactId>
+			<version>${jersey.version}</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-jdk14</artifactId>

--- a/broker-server/pom.xml
+++ b/broker-server/pom.xml
@@ -17,7 +17,8 @@
 	</parent>
 	<properties>
 		<java.util.logging.config.file>src/test/resources/logging.properties</java.util.logging.config.file>
-		<jetty.version>9.4.51.v20230217</jetty.version>
+		<jetty.version>9.4.53.v20231009</jetty.version>
+		<jersey.version>2.41</jersey.version>
 	</properties>
 	<build>
 	 	<plugins>
@@ -147,31 +148,39 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-server</artifactId>
-			<version>2.30.1</version>
+			<version>${jersey.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.containers</groupId>
 			<artifactId>jersey-container-servlet-core</artifactId>
-			<version>2.30.1</version>
+			<version>${jersey.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.containers</groupId>
 			<artifactId>jersey-container-jetty-http</artifactId>
-			<version>2.30.1</version>
+			<version>${jersey.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.inject</groupId>
 			<artifactId>jersey-hk2</artifactId>
-			<version>2.30.1</version>
+			<version>${jersey.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.ext.cdi</groupId>
 			<artifactId>jersey-cdi1x-servlet</artifactId>
-			<version>2.30.1</version>
+			<version>${jersey.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Starting from Jersey 2.30 onwards, JAXB support was moved to a separate module  -->
+		<dependency>
+			<groupId>org.glassfish.jersey.media</groupId>
+			<artifactId>jersey-media-jaxb</artifactId>
+			<version>${jersey.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/broker-server/pom.xml
+++ b/broker-server/pom.xml
@@ -93,7 +93,7 @@
 		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
-			<version>4.19.1</version>
+			<version>4.25.1</version>
 			<exclusions>
 			    <exclusion>
 				<groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Updated dependencies for CVE mitigation:
- liquibase (CVE-2022-1471)
- jetty (CVE-2023-40167)
- jersey (CVE-2021-28168)

Due to the update of Jersey, package "jersey-media-jaxb" has been added to ensure continued Jaxb support